### PR TITLE
issue#64 チームメンバーの編集機能を追加

### DIFF
--- a/app/controllers/assigns_controller.rb
+++ b/app/controllers/assigns_controller.rb
@@ -30,18 +30,23 @@ class AssignsController < ApplicationController
       'リーダーは削除できません。'
     elsif Assign.where(user_id: assigned_user.id).count == 1
       'このユーザーはこのチームにしか所属していないため、削除できません。'
-    elsif assign.destroy
+    elsif current_user.id == assign.team.owner.id
+      assign.destroy
       set_next_team(assign, assigned_user)
       'メンバーを削除しました。'
+    elsif current_user.id == assign.user.id
+      assign.destroy
+      set_next_team(assign, assigned_user)
+      'チームから脱退しました。'
     else
       'なんらかの原因で、削除できませんでした。'
-    end    
-  end  
-  
+    end
+  end
+
   def email_reliable?(address)
     address.match(/\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i)
   end
-  
+
   def set_next_team(assign, assigned_user)
     another_team = Assign.find_by(user_id: assigned_user.id).team
     change_keep_team(assigned_user, another_team) if assigned_user.keep_team_id == assign.team_id

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -4,7 +4,7 @@ class CommentsController < ApplicationController
     @comment = @article.comments.build(comment_params)
     @comment.user_id = current_user.id
     respond_to do |format|
-      if @comment.save!
+      if @comment.save
         format.js { render :index }
       else
         format.html { redirect_to article_path(@article), notice: '投稿できませんでした...' }

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -15,7 +15,9 @@ class TeamsController < ApplicationController
     @team = Team.new
   end
 
-  def edit; end
+  def edit
+    redirect_to @team, notice: 'オーナー以外はチーム情報の編集ができません。' if  current_user.id != @team.owner.id
+  end
 
   def create
     @team = Team.new(team_params)

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -27,7 +27,6 @@
       <p>コメント投稿</p>
       <!-- コメント入力欄をarticleの詳細ページに表示するためのrender -->
       <%= render partial: 'comments/form', locals: { comment: @comment, article: @article } %>
-
       <!-- /.card-body -->
     </div>
     <!-- /.card -->

--- a/app/views/teams/show.html.erb
+++ b/app/views/teams/show.html.erb
@@ -10,7 +10,9 @@
               <%= image_tag default_img(@team.icon_url), class: 'img' %><br>
               <%= @team.name %>
             </div>
-            <%= link_to 'チーム情報を編集する', edit_team_path(@team), class: 'btn btn-success btn-block mt-3' %>
+            <% if current_user.id == @team.owner.id %>
+              <%= link_to 'チーム情報を編集する', edit_team_path(@team), class: 'btn btn-success btn-block mt-3' %>
+            <% end %>
           </div>
 
           <div class="col-md-8">
@@ -41,7 +43,9 @@
                     <tr>
                       <td><%= image_tag 'default.jpg', size: '40x40' %></td>
                       <td><%= assign.user.email %></td>
-                      <td><%= link_to '削除', team_assign_path(@team, assign), method: :delete, class: 'btn btn-sm btn-danger' %></td>
+                      <% if current_user.id == assign.team.owner.id || current_user.id == assign.user.id %>
+                        <td><%= link_to '削除', team_assign_path(@team, assign), method: :delete, class: 'btn btn-sm btn-danger' %></td>
+                      <% end %>
                     </tr>
                   <% end %>
                 </tbody>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -68,4 +68,6 @@ Rails.application.configure do
     Bullet.console = true
     Bullet.rails_logger = true
   end
+  
+  BetterErrors::Middleware.allow_ip! "0.0.0.0/0"
 end


### PR DESCRIPTION
- [x] Teamに所属しているUserの削除（離脱）は、そのTeamのオーナーか、そのUser自身しかできないようにすること
- [x] TeamのeditはTeamのリーダー（オーナー）のみができるようにすること